### PR TITLE
fixed wrong label syntax; concerns #56

### DIFF
--- a/src/metalnx-web/src/main/resources/views/tickets/ticketoperations.html
+++ b/src/metalnx-web/src/main/resources/views/tickets/ticketoperations.html
@@ -68,7 +68,7 @@
         </p>
 
         <p>
-            <label for="ticketPath: th:text="#{resources.table.path.label}"></label> <br />
+            <label for="ticketPath" th:text="#{resources.table.path.label}"></label> <br />
             <span id="ticketPath" th:text="${path}"></span>
         </p>
 


### PR DESCRIPTION
There was a colon in the template instead of a quotation mark. With this, metalnx.enable.tickets in /etc/irods-ext/metalnx.properties can be set to true again. Additionally the caching directory must be created:
mkdir /var/lib/tomcat8/tmp-ticket-files
chown tomcat8.tomcat8 /var/lib/tomcat8/tmp-ticket-files