### PR TITLE
Add new configuration to build image by using multistage builds

### DIFF
--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -31,6 +31,6 @@ RUN wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/5.2
 COPY src/metalnx-tools/src/main/resources/migrations/ /migrations
 COPY packaging/docker/runit.sh /
 COPY --from=builder /usr/src/metalnx/metalnx-web/target/metalnx.war /usr/local/tomcat/webapps/
-COPY packaging/docker/server.xml /conf/server.xml
+COPY packaging/docker/server.xml /usr/local/tomcat/conf/server.xml
 
 CMD ["/runit.sh"]

--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -1,0 +1,36 @@
+FROM maven:3.6.3-jdk-11 as builder
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    sudo \
+    wget \
+    nano \
+    nodejs
+
+COPY src/ /usr/src/metalnx
+
+WORKDIR /usr/src/metalnx
+
+RUN mvn package -Dmaven.test.skip=true
+
+FROM tomcat:jdk11-adoptopenjdk-hotspot
+LABEL organization="iRODS Consortium"
+LABEL description="Metalnx iRODS Browser"
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    less \
+    nano \
+    nodejs \
+    wget
+
+RUN wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/5.2.4/flyway-commandline-5.2.4-linux-x64.tar.gz | tar xvz \
+ && ln -s `pwd`/flyway-5.2.4/flyway /usr/local/bin
+
+COPY src/metalnx-tools/src/main/resources/migrations/ /migrations
+COPY packaging/docker/runit.sh /
+COPY --from=builder /usr/src/metalnx/metalnx-web/target/metalnx.war /usr/local/tomcat/webapps/
+COPY packaging/docker/server.xml /conf/server.xml
+
+CMD ["/runit.sh"]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ make
 
 This will result in a new Docker image named `myimages/metalnx:latest` on your machine.
 
+## Building Metalnx Docker image by using multistage approach
+
+```
+docker build --rm --no-cache -t myimages/metalnx:latest -f Dockerfile.multisage .
+```
+
+This will result in a new Docker image named `myimages/metalnx:latest` on your machine.
+
 ## Deploying Built Metalnx
 
 If you're deploying your own image (built just above):


### PR DESCRIPTION
This approach should simplify the whole build pipeline, because
it runs all the building steps consistently.