### PR TITLE
Fix typo in docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This will result in a new Docker image named `myimages/metalnx:latest` on your m
 ## Building Metalnx Docker image by using multistage approach
 
 ```
-docker build --rm --no-cache -t myimages/metalnx:latest -f Dockerfile.multisage .
+docker build --rm --no-cache -t myimages/metalnx:latest -f Dockerfile.multistage .
 ```
 
 This will result in a new Docker image named `myimages/metalnx:latest` on your machine.


### PR DESCRIPTION
The file it's supposed to reference is https://github.com/irods-contrib/metalnx-web/blob/master/Dockerfile.multistage