### PR TITLE
Use 'exec' to launch tomcat

### DIFF
--- a/packaging/docker/runit.sh
+++ b/packaging/docker/runit.sh
@@ -12,4 +12,4 @@ else
 fi
 
 echo "running catalina"
-catalina.sh run #> /tmp/catalina.out
+exec catalina.sh run


### PR DESCRIPTION
'official' tomcat images run tomcat as PID 1:

```
$ podman top tc
USER   PID   PPID   %CPU    ELAPSED           TTY     TIME   COMMAND
root   1     0      1.201   5m33.192854237s   pts/0   4s     /usr/local/openjdk-11/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp org.apache.catalina.startup.Bootstrap start 
```

But the Metalnx images have a shell as PID 1:

```
$ oc exec deploy/metalnx -- ps -eH
PID  TTY  TIME      CMD
252  ?    00:00:00  ps
1    ?    00:00:00  runit.sh
8    ?    00:10:20    java
```

When stopping a container, `SIGTERM` is sent to pid 1. But the shell doesn't forward that on to its child processes, and so the signal is effectively ignored (until the container manager gets bored and sends `SIGKILL`).

Using `exec` causes the shell to be replaced by the tomcat process, which handles `SIGTERM` and performs a graceful shutdown.

This restores the default behaviour of the `tomcat:jdk11-adoptopenjdk-hotspot` image, which is to run `catalina.sh` as pid 1.