### PR TITLE
175 thumbnail

### DIFF
--- a/docker-test-framework/etc/irods-ext/metalnx.properties
+++ b/docker-test-framework/etc/irods-ext/metalnx.properties
@@ -174,3 +174,5 @@ pluggablepublishing.info.timeout=0
 # timeout for actual publishing, set to 0 for no timeout
 pluggablepublishing.publishing.timeout=0
 
+# server rule engine instance that will provide the galleryview listing
+gallery_view.rule_engine_plugin.instance_name=irods_rule_engine_plugin-irods_rule_language-instance

--- a/src/metalnx-web/src/main/javascript/gallery/components/Gallery.vue
+++ b/src/metalnx-web/src/main/javascript/gallery/components/Gallery.vue
@@ -1,299 +1,107 @@
 <template>
   <!-- Search -->
   <div>
-    <div class="widgetsContainer">
-      <span>{{ formattedPath }}</span>
-      <span class="widgets">
-        <b-link
-          href="#"
-          class="btn btn-default icon-btn"
-          id="showCollectionFormBtn"
-          aria-label="add collection"
-          title="add collection"
-        >
-          <i class="fa fa-folder"></i>
-        </b-link>
-        <b-link
-          class="btn btn-default icon-btn"
-          :href="`/metalnx/collectionInfo${url}`"
-          id="infoIcon"
-          title="View info"
-          ><i class="fa fa-info-circle fa-color"></i>
-        </b-link>
-        <b-link
-          href="#"
-          class="btn btn-default icon-btn"
-          aria-label="upload files"
-          id="uploadIcon"
-          title="Upload file(s) to iRODS"
-        >
-          <i class="fa fa-cloud-upload fa-color"></i>
-        </b-link>
-        <b-link
-          :href="`/metalnx/collections${url}`"
-          class="btn btn-default icon-btn"
-          id="collectionIcon"
-          title="Collection List View"
-          ><i class="fa fa-list fa-lg" aria-hidden="true"></i
-        ></b-link>
-      </span>
+    <div class="gallery-widgets-container">
+      <GalleryPath v-bind:pathArray="pathArray" />
+      <GalleryWidgets v-bind:url="url" />
     </div>
-    <div class="paginationContainer">
-    <b-pagination-nav 
-      active="true"
-      class="gallery-nav"
-      v-model="currentPage"
-      :link-gen="linkGen"
-      :number-of-pages="10"
-    />
-    <b-form-select
-          v-model="size_selected"
-          class="thumbnail-size-select"
-          :options="size_options"
-        >
-        <b-form-select-option :value="null" disabled>-- Select thumbnail size --</b-form-select-option>
-    </b-form-select>
-    <b-form-select
-          v-model="items_selected"
-          class="thumbnail-items-select"
-          :options="items_options"
-          @change="updateItemPerPage(items_selected)"
-        >
-        <b-form-select-option :value="null" disabled>-- Select items per page --</b-form-select-option>
-    </b-form-select>
+    <!-- <GalleryPagination v-bind:url="url" /> -->
+    <div v-if="!thumbnails || thumbnails['error']">
+      <b-alert show variant="danger" class="gallery-notification"
+        >{{ thumbnail_error_message }} Please click
+        <b-link :href="`/metalnx/collections${url}`">here</b-link> to go back to
+        collection browser.</b-alert
+      >
     </div>
-    <div class="galleryContainer">
-      <div class="gallery" v-for="item in demo.items">
-        <a
-          :id="'thumbnail' + item.id"
-          :href="`/metalnx/collectionInfo${url}%2F${item.name}`"
-        >
-          <i v-if="item.collection" class="fas fa-folder-open"></i>
-          <img v-else v-bind:class="[size_selected]" :src="item.thumbnails" />
-          <div class="thumbnail_name">{{ item.name }}</div>
-        </a>
-        <b-tooltip :target="'thumbnail' + item.id" triggers="hover">
-          <div>File Size: {{ item.fileSize }}</div>
-          <div>File Type: {{ item.fileType }}</div>
-        </b-tooltip>
-      </div>
+    <div v-else class="gallery-item-container">
+      <GalleryItem
+        v-for="item in thumbnails.items"
+        v-bind:path="fullPath"
+        v-bind:item="item"
+        :key="item.id"
+      />
     </div>
   </div>
 </template>
 
 <script>
 import axios from "axios";
+import GalleryItem from "./GalleryItem.vue";
+import GalleryPath from "./GalleryPath.vue";
+import GalleryWidgets from "./GalleryWidgets.vue";
+import GalleryPagination from "./GalleryPagination.vue";
 
 export default {
   name: "Gallery",
-  components: {},
+  components: { GalleryItem, GalleryPath, GalleryWidgets, GalleryPagination },
   data() {
-    const currentUrl = window.location;
     const url = window.location.search;
-    const params = new URLSearchParams(url.substring(1));
-    const path = decodeURIComponent(params.get("path"));
-    const formattedPath = path.substring(1).replaceAll("/", " >> ");
-
     // Retrieve items per page and current page from url
-    const perPage = params.get("perPage");
-    const currentPage = params.get("currentPage");
-
-    let response = axios({
-      method: "GET",
-      url: "/metalnx/api/gallery",
-      params: {
-        path: "/tempZone/home/test1",
-        offset: 0,
-        limit: 100,
-      },
-    }).catch((e) => console.log(e));
-
-    var demo = {
-      location: "testLocation",
-      items: [
-        {
-          id: 1,
-          name: "sample1.png",
-          lastModified: "2020-12-14",
-          thumbnails: "./img/sample1.png",
-          fileSize: "10 MB",
-          fileType: "Portable Network Graphics",
-        },
-        {
-          id: 2,
-          name: "sample2.png",
-          lastModified: "2020-12-14",
-          thumbnails: "./img/sample2.png",
-          fileSize: "10 MB",
-          fileType: "Portable Network Graphics",
-        },
-        {
-          id: 3,
-          name: "sample3.png",
-          lastModified: "2020-12-14",
-          thumbnails: "./img/sample3.png",
-          fileSize: "10 MB",
-          fileType: "Portable Network Graphics",
-        },
-        {
-          id: 4,
-          name: "sample4.png",
-          lastModified: "2020-12-14",
-          thumbnails: "./img/sample7.png",
-          fileSize: "10 MB",
-          fileType: "Portable Network Graphics",
-        },
-        {
-          id: 5,
-          name: "sample5.png",
-          lastModified: "2020-12-14",
-          thumbnails: "./img/sample5.png",
-          fileSize: "10 MB",
-          fileType: "Portable Network Graphics",
-        },
-        {
-          id: 6,
-          name: "sample6.png",
-          lastModified: "2020-12-14",
-          thumbnails: "./img/sample6.png",
-          fileSize: "10 MB",
-          fileType: "Portable Network Graphics",
-        },
-        {
-          id: 7,
-          name: "sample7.png",
-          lastModified: "2020-12-14",
-          thumbnails: "./img/sample7.png",
-          fileSize: "10 MB",
-          fileType: "Portable Network Graphics",
-        },
-        {
-          id: 8,
-          name: "sample8.png",
-          lastModified: "2020-12-14",
-          thumbnails: "./img/sample8.png",
-          fileSize: "10 MB",
-          fileType: "Portable Network Graphics",
-        },
-        {
-          id: 9,
-          name: "sample9.png",
-          lastModified: "2020-12-14",
-          thumbnails: "./img/sample9.png",
-          fileSize: "10 MB",
-          fileType: "Portable Network Graphics",
-        },
-        {
-          id: 10,
-          name: "sample10.png",
-          lastModified: "2020-12-14",
-          thumbnails: "./img/sample10.png",
-          fileSize: "10 MB",
-          fileType: "Portable Network Graphics",
-        },
-      ],
-    };
+    const params = new URLSearchParams(url.substring(1));
+    const fullPath = decodeURIComponent(params.get("path"));
+    const formattedPath = fullPath.substring(1);
+    const pathArray = formattedPath.split("/");
+    const currPerPage =
+      params.get("perPage") === null ? 10 : params.get("perPage");
+    const currPage = params.get("page") === null ? 1 : params.get("page");
+    const currSize = params.get("size") === null ? "small" : params.get("size");
     return {
-      demo,
-      currentUrl,
       url,
-      path,
+      fullPath,
+      pathArray,
       formattedPath,
-      currentPage,
-      perPage,
-      response,
-      size_selected: null,
-      size_options: ["small", "medium", "large"],
-      items_selected: null,
-      items_options: [25,50,75,100],
+      currPerPage,
+      currPage,
+      currSize,
+      thumbnails: {},
+      thumbnail_error_message:
+        "An error has occurred while fetching thumbnail data from iRODS.",
     };
   },
   methods: {
-    linkGen(pageNum) {
-      return `/gallery?path=${encodeURIComponent(this.path)}&currentPage=${pageNum}&perPage=${this.perPage}`
+    async fetchThumbnails() {
+      try {
+        let response = await axios({
+          method: "GET",
+          url: "/metalnx/api/gallery",
+          params: {
+            path: this.fullPath,
+            offset: this.currPerPage * (this.currPage - 1),
+            limit: this.currPerPage,
+          },
+        });
+        this.thumbnails = response.data;
+      } catch (err) {
+        if (err.response) {
+          this.thumbnail_error_message += err.response;
+        } else if (err.request) {
+          this.thumbnail_error_message += " Client never receives response.";
+        } else {
+          this.thumbnail_error_message += " Client error.";
+        }
+      }
     },
-    updateItemPerPage(newPerPage){
-      window.location = `/gallery?path=${encodeURIComponent(this.path)}&currentPage=${this.currentPage}&perPage=${newPerPage}`;
-    }
-  }
+  },
+  mounted() {
+    this.fetchThumbnails();
+  },
 };
 </script> 
 <style>
-.large {
-  width: 125px;
-  height: 125px;
-}
-
-.galleryContainer {
+.gallery-widgets-container {
   max-width: 100%;
-  margin-left: 20px;
-  margin-top: 40px;
-  margin-right: 20px;
-  padding-left: 15px;
-  padding-right: 15px;
   display: flex;
   flex-flow: row wrap;
-  align-content: flex-start;
+  align-content: space-between;
 }
 
-.medium {
-  width: 100px;
-  height: 100px;
-}
-
-.small {
-  width: 75px;
-  height: 75px;
-}
-
-.thumbnail_select {
-  width: 100px;
-  margin: 20px 10px auto 40px;
-}
-
-.gallery {
-  margin: 10px 20px 10px 20px;
+.gallery-notification {
   text-align: center;
 }
 
-.gallery-nav{
-  margin: 10px 10px 10px 30px;
-}
-
-.thumbnail_name {
-  margin: 5px auto 5px auto;
-}
-
-.collection_view {
-  float: right;
-  margin-top: 25px;
-  margin-right: 140px;
-}
-
-.paginationContainer{
+.gallery-item-container {
   display: flex;
-  flex-direction: row;
-}
-
-.widgetsContainer {
-  margin-top: 20px;
-  margin-left: 20px;
-  display: "flex";
-  flex-direction: column;
-}
-.thumbnail-size-select{
-  margin-top: 10px;
-  margin-left: 10px;
-  width: auto;
-}
-
-.thumbnail-items-select{
-  margin-top: 10px;
-  margin-left: 10px;
-  width: auto;
-}
-
-.widgets {
-  margin-left: 35%;
+  flex-flow: row wrap;
+  align-content: flex-start;
 }
 </style>

--- a/src/metalnx-web/src/main/javascript/gallery/components/GalleryItem.vue
+++ b/src/metalnx-web/src/main/javascript/gallery/components/GalleryItem.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="gallery-item">
+    <a
+      :id="'thumbnail' + item.id"
+      v-if="item.collection"
+      :href="`/metalnx/gallery?path=${path}%2F${item.name}`"
+    >
+      <i class="fa fa-folder fa-3x" />
+      <div class="gallery-item_name">{{ item.name }}</div>
+    </a>
+    <a
+      :id="'thumbnail' + item.id"
+      v-else
+      :href="`/metalnx/collectionInfo?path=${path}%2F${item.name}`"
+    >
+      <i class="fa fa-file fa-3x" />
+      <div class="gallery-item_name">{{ item.name }}</div>
+    </a>
+    <b-tooltip :target="'thumbnail' + item.id" triggers="hover">
+      <div>File Name: {{ item.name }}</div>
+    </b-tooltip>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "GalleryItem",
+  components: {},
+  props: ["item", "path"],
+  data() {
+    return {};
+  },
+};
+</script> 
+<style>
+.gallery-item {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  height: 200px;
+  justify-content: center;
+  text-align: center;
+}
+
+.gallery-item_name {
+  width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/src/metalnx-web/src/main/javascript/gallery/components/GalleryPagination.vue
+++ b/src/metalnx-web/src/main/javascript/gallery/components/GalleryPagination.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="gallery-pagination-container">
+    <b-pagination-nav
+      active="true"
+      class="gallery-nav"
+      v-model="currentPage"
+      :link-gen="linkGen"
+      :number-of-pages="10"
+    />
+    <b-form-select
+      v-model="size_selected"
+      class="thumbnail-size-select"
+      :options="size_options"
+    >
+      <b-form-select-option :value="null" disabled
+        >-- Select thumbnail size --</b-form-select-option
+      >
+    </b-form-select>
+    <b-form-select
+      v-model="items_selected"
+      class="thumbnail-items-select"
+      :options="items_options"
+      @change="updateItemPerPage(items_selected)"
+    >
+      <b-form-select-option :value="null" disabled
+        >-- Select items per page --</b-form-select-option
+      >
+    </b-form-select>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "GalleryContextProvider",
+  components: {},
+  props:['currPerPage','currPage','currSize'],
+  data() {
+    return {
+      size_options: ["small", "medium", "large"],
+      items_options: [10, 25, 50, 75, 100],
+    };
+  },
+  methods: {
+    linkGen(pageNum) {
+      return `/metalnx/gallery?path=${encodeURIComponent(
+        this.currPath
+      )}&page=${pageNum}&perPage=${this.currPerPage}&size=${this.currSize}`;
+    },
+    updateItemPerPage(newPerPage) {
+      window.location = `/metalnx/gallery?path=${encodeURIComponent(
+        this.currPath
+      )}&page=${this.currPage}&perPage=${newPerPage}&size=${this.currSize}`;
+    },
+    updateThumbnailSize(newSize) {
+      window.location = `/metalnx/gallery?path=${encodeURIComponent(
+        this.currPath
+      )}&page=${this.currPage}&perPage=${this.currPerPage}&size=${newSize}`;
+    },
+  },
+};
+</script> 
+<style>
+.gallery-pagination-container {
+  display: flex;
+  flex-direction: row;
+}
+
+.gallery-nav {
+  margin: 10px 10px 10px 30px;
+}
+
+.thumbnail-size-select {
+  margin-top: 10px;
+  margin-left: 10px;
+  width: 100px;
+}
+
+.thumbnail-items-select {
+  margin-top: 10px;
+  margin-left: 10px;
+  width: 300px;
+}
+</style>

--- a/src/metalnx-web/src/main/javascript/gallery/components/GalleryPath.vue
+++ b/src/metalnx-web/src/main/javascript/gallery/components/GalleryPath.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="gallery-path-container">
+    <span :key="path" v-for="(path, index) in pathArray">
+      <i
+        v-if="index !== 0"
+        class="fa fa-angle-double-right path gallery-right-shift"
+      ></i
+      ><a class="gallery-path" v-bind:href="generateUrl(pathArray, path)">
+        {{ path }}
+      </a>
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "GalleryContextProvider",
+  components: {},
+  props: ["pathArray"],
+  data() {
+    return {};
+  },
+  methods: {
+    generateUrl(paths, path) {
+      let index = paths.indexOf(path);
+      let url = "/metalnx/gallery?path=";
+      for (let i = 0; i <= index; i++) {
+        url += encodeURIComponent("/" + paths[i]);
+      }
+      return url;
+    },
+  },
+};
+</script> 
+<style>
+.gallery-path-container {
+  width: 60%;
+}
+.gallery-right-shift {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+.gallery-path {
+  color: #287ea1;
+}
+</style>

--- a/src/metalnx-web/src/main/javascript/gallery/components/GalleryWidgets.vue
+++ b/src/metalnx-web/src/main/javascript/gallery/components/GalleryWidgets.vue
@@ -1,0 +1,49 @@
+<template>
+  <span>
+    <b-link
+      href="#"
+      class="btn btn-default icon-btn"
+      id="showCollectionFormBtn"
+      aria-label="add collection"
+      title="add collection"
+    >
+      <i class="fa fa-folder"></i>
+    </b-link>
+    <b-link
+      class="btn btn-default icon-btn"
+      :href="`/metalnx/collectionInfo${url}`"
+      id="infoIcon"
+      title="View info"
+      ><i class="fa fa-info-circle fa-color"></i>
+    </b-link>
+    <b-link
+      href="#"
+      class="btn btn-default icon-btn"
+      aria-label="upload files"
+      id="uploadIcon"
+      title="Upload file(s) to iRods"
+    >
+      <i class="fa fa-cloud-upload fa-color"></i>
+    </b-link>
+    <b-link
+      :href="`/metalnx/collections${url}`"
+      class="btn btn-default icon-btn"
+      id="collectionIcon"
+      title="Collection List View"
+      ><i class="fa fa-list fa-lg" aria-hidden="true"></i
+    ></b-link>
+  </span>
+</template>
+
+<script>
+export default {
+  name: "GalleryWidgets",
+  components: {},
+  props: ['url'],
+  data() {
+    return {};
+  },
+};
+</script> 
+<style>
+</style>

--- a/src/metalnx-web/src/main/resources/static/css/styles.css
+++ b/src/metalnx-web/src/main/resources/static/css/styles.css
@@ -3133,91 +3133,50 @@ legend.scheduler-border {
 }
 
 /* ------------------------------------ Gallery View -------------------------------------------------- */
-
-.large {
-	width: 125px;
-	height: 125px;
-  }
-  
-  .galleryContainer {
+.gallery-widgets-container {
 	max-width: 100%;
-	margin-left: 20px;
-	margin-top: 40px;
-	margin-right: 20px;
-	padding-left: 15px;
-	padding-right: 15px;
+	display: flex;
+	flex-flow: row wrap;
+	align-content: space-between;
+  }
+
+.gallery-notification {
+	text-align: center;
+}
+
+.gallery-item-container {
+	max-width: 100%;
 	display: flex;
 	flex-flow: row wrap;
 	align-content: flex-start;
   }
-  
-  .medium {
-	width: 100px;
-	height: 100px;
+
+.gallery-path-container {
+	width: 60%;
   }
-  
-  .small {
-	width: 75px;
-	height: 75px;
+
+.gallery-right-shift {
+	padding-left: 5px;
+	padding-right: 5px;
   }
-  
-  .thumbnail_select {
-	width: 100px;
-	margin: 20px 10px auto 40px;
+
+.gallery-path {
+	color: #287ea1;
   }
+
   
-  .gallery {
-	margin: 10px 20px 10px 20px;
+.gallery-item {
+	display: flex;
+	flex-direction: column;
+	width: 200px;
+	height: 200px;
+	justify-content: center;
 	text-align: center;
   }
   
-  .gallery-nav{
-	margin: 10px 10px 10px 30px;
-  }
-  
-  .thumbnail_name {
-	margin: 5px auto 5px auto;
-  }
-  
-  .collection_view {
-	float: right;
-	margin-top: 25px;
-	margin-right: 140px;
-  }
-  
-  .paginationContainer{
-	display: flex;
-	flex-direction: row;
-  }
-  
-  .widgetsContainer {
-	margin-top: 20px;
-	margin-left: 20px;
-	display: "flex";
-	flex-direction: column;
-  }
-  .thumbnail-size-select{
-	margin-top: 10px;
-	margin-left: 10px;
-	width: 100px;
-  }
-  
-  .thumbnail-items-select{
-	margin-top: 10px;
-	margin-left: 10px;
-	width: 300px;
-  }
-  
-  .widgets {
-	margin-left: 35%;
-  }
-
-  .path {
-	color: #287EA1;
-	font-size: 14px;
-  }
-  
-  .right-shift {
-	padding-left: 0.5px;
-	padding-right: 0.5px;
+.gallery-item_name {
+	width: 180px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
   }

--- a/src/metalnx-web/src/main/resources/views/collections/collectionsBrowser.html
+++ b/src/metalnx-web/src/main/resources/views/collections/collectionsBrowser.html
@@ -222,9 +222,9 @@
 <!-- /Add Modal -->
 
 <!-- Bread Crumb -->
-<div id="directoryPath" class="col-md-10 col-sm-9 col-xs-12"
+<div id="directoryPath" class="col-md-9 col-sm-8 col-xs-12"
 	th:include="${'collections/collectionsBreadCrumb'}"></div>
-<div class="col-md-2 col-sm-3 col-xs-12">
+<div class="col-md-3 col-sm-4 col-xs-12">
 	<a aria-label="empty trash" title="empty trash" href="#"
 		th:if="${isTrash}" id="emptyTrashBtn"
 		th:title="#{collections.empty.trash.button.tooltip}"


### PR DESCRIPTION
This pr
- Refactored galleryview container and extract each item as component
- Detect the type of each item from rule engine and render icon accordingly, whether it is collection or static file. Once we know how we generate and visit thumbnails, I can update its path so real thumbnails can be displayed
- Clicking collection item will navigate user to that directory
- Add navigation on the top path directory bar, just like the collection page
- Add error handling when there is no irods rule engine or error occurs when fetching data