### PR TITLE
render thumbnail path

### DIFF
--- a/src/metalnx-web/src/main/javascript/gallery/components/GalleryItem.vue
+++ b/src/metalnx-web/src/main/javascript/gallery/components/GalleryItem.vue
@@ -18,7 +18,7 @@
       <div class="gallery-thumbnail">
         <img
           alt="Thumbnail Image"
-          :src="item.thumbnail"
+          :src="item.previewSrc"
           class="gallery-thumbnail"
         />
       </div>
@@ -32,6 +32,8 @@
 </template>
 
 <script>
+import axios from "axios";
+
 export default {
   name: "GalleryItem",
   components: {},
@@ -39,6 +41,28 @@ export default {
   data() {
     return {};
   },
+  // methods: {
+  //   async fetchPreview() {
+  //     let preview_prep_response = await axios({
+  //       method: "GET",
+  //       url: "/metalnx/previewPreparation/",
+  //       params: {
+  //         path: `${this.item.thumbnail}`,
+  //       },
+  //     });
+  //     let preview_response = await axios({
+  //       method: "GET",
+  //       url: "/metalnx/preview/dataObjectPreview/",
+  //       responseType: 'blob'
+  //     });
+  //     this.preview_response = preview_response;
+  //     console.log(preview_response);
+  //     this.previewSrc = URL.createObjectURL(preview_response.data);
+  //   },
+  // },
+  // mounted() {
+  //   this.fetchPreview();
+  // },
 };
 </script> 
 <style>
@@ -72,5 +96,4 @@ export default {
   justify-content: center;
   object-fit: scale-down;
 }
-
 </style>

--- a/src/metalnx-web/src/main/javascript/gallery/components/GalleryItem.vue
+++ b/src/metalnx-web/src/main/javascript/gallery/components/GalleryItem.vue
@@ -32,8 +32,6 @@
 </template>
 
 <script>
-import axios from "axios";
-
 export default {
   name: "GalleryItem",
   components: {},
@@ -41,28 +39,6 @@ export default {
   data() {
     return {};
   },
-  // methods: {
-  //   async fetchPreview() {
-  //     let preview_prep_response = await axios({
-  //       method: "GET",
-  //       url: "/metalnx/previewPreparation/",
-  //       params: {
-  //         path: `${this.item.thumbnail}`,
-  //       },
-  //     });
-  //     let preview_response = await axios({
-  //       method: "GET",
-  //       url: "/metalnx/preview/dataObjectPreview/",
-  //       responseType: 'blob'
-  //     });
-  //     this.preview_response = preview_response;
-  //     console.log(preview_response);
-  //     this.previewSrc = URL.createObjectURL(preview_response.data);
-  //   },
-  // },
-  // mounted() {
-  //   this.fetchPreview();
-  // },
 };
 </script> 
 <style>

--- a/src/metalnx-web/src/main/javascript/gallery/components/GalleryItem.vue
+++ b/src/metalnx-web/src/main/javascript/gallery/components/GalleryItem.vue
@@ -3,21 +3,30 @@
     <a
       :id="'thumbnail' + item.id"
       v-if="item.collection"
+      class="gallery-item_anchor"
       :href="`/metalnx/gallery?path=${path}%2F${item.name}`"
     >
-      <i class="fa fa-folder fa-3x" />
+      <div class="gallery-thumbnail"><i class="fa fa-folder fa-3x" /></div>
       <div class="gallery-item_name">{{ item.name }}</div>
     </a>
     <a
       :id="'thumbnail' + item.id"
       v-else
+      class="gallery-item_anchor"
       :href="`/metalnx/collectionInfo?path=${path}%2F${item.name}`"
     >
-      <i class="fa fa-file fa-3x" />
+      <div class="gallery-thumbnail">
+        <img
+          alt="Thumbnail Image"
+          :src="item.thumbnail"
+          class="gallery-thumbnail"
+        />
+      </div>
       <div class="gallery-item_name">{{ item.name }}</div>
     </a>
     <b-tooltip :target="'thumbnail' + item.id" triggers="hover">
-      <div>File Name: {{ item.name }}</div>
+      <div>Name: {{ item.name }}</div>
+      <div>{{ item.hover }}</div>
     </b-tooltip>
   </div>
 </template>
@@ -36,16 +45,32 @@ export default {
 .gallery-item {
   display: flex;
   flex-direction: column;
-  width: 200px;
+  width: 150px;
   height: 200px;
+  margin: 10px;
+  align-items: center;
   justify-content: center;
   text-align: center;
 }
 
 .gallery-item_name {
-  width: 180px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  width: 150px;
 }
+
+.gallery-item_anchor:hover {
+  text-decoration: none;
+}
+
+.gallery-thumbnail {
+  height: 150px;
+  width: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  object-fit: scale-down;
+}
+
 </style>

--- a/src/metalnx-web/src/main/javascript/gallery/components/GalleryWidgets.vue
+++ b/src/metalnx-web/src/main/javascript/gallery/components/GalleryWidgets.vue
@@ -1,6 +1,6 @@
 <template>
-  <span>
-    <b-link
+  <span class="gallery-widgets">
+    <!-- <b-link
       href="#"
       class="btn btn-default icon-btn"
       id="showCollectionFormBtn"
@@ -8,7 +8,7 @@
       title="add collection"
     >
       <i class="fa fa-folder"></i>
-    </b-link>
+    </b-link> -->
     <b-link
       class="btn btn-default icon-btn"
       :href="`/metalnx/collectionInfo${url}`"
@@ -16,7 +16,7 @@
       title="View info"
       ><i class="fa fa-info-circle fa-color"></i>
     </b-link>
-    <b-link
+    <!-- <b-link
       href="#"
       class="btn btn-default icon-btn"
       aria-label="upload files"
@@ -24,7 +24,7 @@
       title="Upload file(s) to iRods"
     >
       <i class="fa fa-cloud-upload fa-color"></i>
-    </b-link>
+    </b-link> -->
     <b-link
       :href="`/metalnx/collections${url}`"
       class="btn btn-default icon-btn"
@@ -39,11 +39,15 @@
 export default {
   name: "GalleryWidgets",
   components: {},
-  props: ['url'],
+  props: ["url"],
   data() {
     return {};
   },
 };
 </script> 
 <style>
+.gallery-widgets {
+  position: absolute;
+  right: 5px;
+}
 </style>

--- a/src/metalnx-web/src/main/resources/static/css/styles.css
+++ b/src/metalnx-web/src/main/resources/static/css/styles.css
@@ -3140,6 +3140,11 @@ legend.scheduler-border {
 	align-content: space-between;
   }
 
+  .gallery-widgets {
+	position: absolute;
+	right: 5px;
+  }
+
 .gallery-notification {
 	text-align: center;
 }
@@ -3168,15 +3173,31 @@ legend.scheduler-border {
 .gallery-item {
 	display: flex;
 	flex-direction: column;
-	width: 200px;
+	width: 150px;
 	height: 200px;
+	margin: 5px;
 	justify-content: center;
+	align-items: center;
 	text-align: center;
   }
   
-.gallery-item_name {
-	width: 180px;
+  .gallery-item_name {
+	padding: 0px 10px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	width: 150px;
+  }
+  
+  .gallery-item_anchor:hover {
+	text-decoration: none;
+  }
+
+  .gallery-thumbnail {
+	height: 150px;
+	width: 150px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	object-fit: scale-down;
   }

--- a/src/metalnx-web/src/main/resources/static/css/styles.css
+++ b/src/metalnx-web/src/main/resources/static/css/styles.css
@@ -3140,6 +3140,12 @@ legend.scheduler-border {
 	align-content: space-between;
   }
 
+.gallery-loading-spinner {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
   .gallery-widgets {
 	position: absolute;
 	right: 5px;


### PR DESCRIPTION
This pr 
- rendered thumbnail based on the absolute path rule engine provided, and the previous file icon has been removed
- large thumbnails will be scaled down to fit into our gallery components
- justify the gallery container so it can work well under different resolutions
- default hover information will include the full name and all data from "hover" property in the response

I have used some static images as thumbnails, see down below: 
![Screen Shot 2021-05-18 at 3 16 35 PM](https://user-images.githubusercontent.com/33065086/118712198-7e0fdb80-b7ee-11eb-97c0-1c35bf1d2955.png)