### PR TITLE
Modify rename dialog header and layout

### DIFF
--- a/src/metalnx-web/src/main/resources/i18n/messages_en.properties
+++ b/src/metalnx-web/src/main/resources/i18n/messages_en.properties
@@ -508,6 +508,7 @@ collections.form.no.access.error=You do not have rights to create collection {0}
 
 ## Collection modification form
 collections.edit.form.title=Modify Collection
+collections.rename.form.title=Rename Collection
 
 ##Collection information
 collections.management.table.datapath.label=DataPath

--- a/src/metalnx-web/src/main/resources/views/collections/summary.html
+++ b/src/metalnx-web/src/main/resources/views/collections/summary.html
@@ -102,9 +102,7 @@
 								th:text="${ dataProfile.getChildName() }"
 								th:title="${ dataProfile.getChildName() }"> </span></li>
 						</th:block>
-
 					</th:block>
-
 					<th:block th:if="${breadcrumb.items.size()} gt 4">
 						<li>...</li>
 						<li><a href="#"
@@ -168,7 +166,6 @@
 
 		<!-- <div class="col-xs-12 col-md-10 col-sm-9 ">
 			 <span class="resulting-permission" th:text="${ '[' + collectionAndDataObject.getMostPermissiveAccessForCurrentUser() + ' access]'}"></span>
-
 		</div> -->
 		<!-- <div class="row box box-default">
 			<div class="col-xs-12 col-md-3 col-sm-3 text-left">
@@ -263,7 +260,7 @@
 							<span aria-hidden="true">&times;</span> <span class="sr-only">Close</span>
 						</button>
 						<h4 class="modal-title" id="myRenameModalLabel"
-							th:text="#{collections.add.form.title}"></h4>
+							th:text="#{collections.rename.form.title}"></h4>
 					</div>
 					<div class="modal-body">
 
@@ -276,6 +273,11 @@
 								<input type="hidden" id="inputCollectionParentPath"
 									name="parentPath" th:value="${ dataProfile.getParentPath() }"
 									title="parentpath" />
+                                
+                                <div class="form-group">
+                                    <b><span th:text="#{collections.add.form.current.path}"></span></b><br />
+                                    <span th:text="${dataProfile.getAbsolutePath()}"></span>
+                                </div>
 
 								<div class="form-group">
 									<label for="inputCollectionName"
@@ -332,20 +334,20 @@
 				</div>
 				<div class="modal-body container">
 
-					<div class="row">
+					<div >
 						<div class="col">
 							<span
 								th:text="#{collections.management.inheritance.modal.prompt}"></span>
 						</div>
 					</div>
-					<div class="row pb-3">
+					<div class="pb-3">
 						<div class="col">
 								<label for="inheritCollectionAbsolutePath"
 
 											th:text="#{collections.management.table.absolute.path.label}" class="text-center"></label>
 						</div>
 					</div>
-					<div class="row pb-5">
+					<div class="pb-5">
 
 						<div class="col">
 								<span id="inheritCollectionAbsolutePath"
@@ -463,4 +465,3 @@
 
 
 </th:block>
-


### PR DESCRIPTION
This pr fixes this [issue](https://github.com/irods-contrib/metalnx-web/issues/253) by modifying rename dialog. There are two pop ups to rename a collection mentioned in that issue. The second pop up was not the same as the first one. 

After changes, clicking 'rename' button on collection info page will now take you to this dialog:
 (Notice I changed 'Add Collection' to 'Rename Collection', and added current path)
![image](https://user-images.githubusercontent.com/33065086/127333392-8fde0906-07a3-42e6-809b-3470a104f184.png)

I didn't change that name to 'Modify Collection' as the first popup, because there is an existing update inheritance modal on collection info page to handle permission inheritance.
![image](https://user-images.githubusercontent.com/33065086/127333813-f8a383f7-61c2-443f-acd5-2891dcf4be33.png)

Let me know if that makes sense.
