### PR TITLE
[254] Conditional rendering based on permissionType

### DIFF
--- a/src/metalnx-web/src/main/java/com/emc/metalnx/controller/CollectionInfoController.java
+++ b/src/metalnx-web/src/main/java/com/emc/metalnx/controller/CollectionInfoController.java
@@ -89,8 +89,11 @@ public class CollectionInfoController {
 		IconObject icon = null;
 		String mimeType = "";
 		String template = "";
-
+		
+     	String permissionType = collectionService.getPermissionsForPath(myPath);
+		model.addAttribute("permissionType", permissionType);
 		boolean access = collectionService.canUserAccessThisPath(path);
+		model.addAttribute("access", access);
 		logger.info("Has Access :: {}", access);
 		@SuppressWarnings("rawtypes")
 		DataProfile dataProfile = null;

--- a/src/metalnx-web/src/main/resources/views/collections/summary.html
+++ b/src/metalnx-web/src/main/resources/views/collections/summary.html
@@ -12,7 +12,7 @@
 
 			<div class="col-sm-4 col-md-4 col-xs-4 pull-right">
 				<div id="actionmenu" class="pull-right">
-					<div class="btn-group">
+					<div class="btn-group" th:if="${permissionType == 'write' or permissionType == 'own'}">
 						<button type="button"
 							class="btn btn-default dropdown-toggle text-btn"
 							data-toggle="dropdown" aria-expanded="false">


### PR DESCRIPTION
After having a deeper understanding of Metalnx, I think this might be the easiest way to fix this [issue](https://github.com/irods-contrib/metalnx-web/issues/254). The java controller will now pass along a new attribute 'permissionType' and template page will do the conditional rendering job. 

If a user has write permission or above (owner), action dropdown menu will be available.
![image](https://user-images.githubusercontent.com/33065086/127918163-6d3ab460-eb76-49d7-a642-a8206c53817c.png)

If not, it won't render.
![image](https://user-images.githubusercontent.com/33065086/127918113-756e9a42-52fd-4c6b-8d7d-e9414e18129b.png)


