### PR TITLE
257/preview permission

### DIFF
--- a/src/metalnx-web/src/main/resources/static/js/collection.js
+++ b/src/metalnx-web/src/main/resources/static/js/collection.js
@@ -23,7 +23,7 @@ function getPermissionDetails(path){
 	ajaxEncapsulation(url, "POST", {path: path}, displayPermissionDetails, null, null);
 }
 
-function getPerview(path){
+function getPreview(path){
 	console.log("Collection getPreview() :: " + path)
 	var url = "/metalnx/previewPreparation/";
 	ajaxEncapsulation(url, "GET", {path:path}, displayPreviewImage, null, null);

--- a/src/metalnx-web/src/main/resources/views/collections/fileInfo.html
+++ b/src/metalnx-web/src/main/resources/views/collections/fileInfo.html
@@ -40,8 +40,8 @@
 								title="Permissions">Permissions</span>
 						</a></li>
 
-						<li><a href="#preview" data-toggle="tab" role="tab"
-							th:onclick="'javascript:getPerview(\'' + ${dataProfile.absolutePath} + '\');'">
+						<li th:if="${permissionType == 'read' or permissionType == 'write' or permissionType == 'own'}"><a href="#preview" data-toggle="tab" role="tab"
+							th:onclick="'javascript:getPreview(\'' + ${dataProfile.absolutePath} + '\');'">
 								<span><i class="fa fa-eye"></i></span> <span title="preview">Preview</span>
 						</a></li>
 					</ul>
@@ -52,7 +52,7 @@
 						</div>
 						<div id="metadata" class="tab-pane fade" role="tabpanel"></div>
 						<div id="permission" class="tab-pane fade" role="tabpanel"></div>
-						<div id="preview" class="tab-pane fade" role="tabpanel">
+						<div id="preview" class="tab-pane fade" role="tabpanel" th:if="${permissionType == 'read' or permissionType == 'write' or permissionType == 'own'}">
 						</div>
 
 					</div>

--- a/src/metalnx-web/src/main/resources/views/collections/preview.html
+++ b/src/metalnx-web/src/main/resources/views/collections/preview.html
@@ -8,6 +8,7 @@
 			<div class="preview-img-container">
 				<img src="/metalnx/preview/dataObjectPreview/"
 					alt="imagePreview" />
+				<span th:text="${permissionType}"></span>
 			</div>
 		</div>
 	</div>
@@ -39,9 +40,9 @@
 			</textarea>
 		</div>
 		<div id="collectionPreviewSearchButtons" class="col-sm-12">
-			<button class="btn btn-primary btn-sm pull-right" type="button"
+			<button th:if="${permissionType == 'own' or permissionType == 'write'}" class="btn btn-primary btn-sm pull-right" type="button"
 				th:onclick="'javascript:save();'" title="Save">Save</button>
-			<button class="btn btn-default btn-sm pull-right" type="button"
+			<button th:if="${permissionType == 'own' or permissionType == 'write'}" class="btn btn-default btn-sm pull-right" type="button"
 				th:onclick="'javascript:cancel();'" title="Cancel">Cancel</button>
 		</div>
 
@@ -55,8 +56,8 @@
 			CSV File Preview....
 			<div id="csv" class="preview"></div>
 
-			<button th:onclick="'javascript:save();'">Save</button>
-			<button th:onclick="'javascript:cancel();'">Cancel</button>
+			<button th:if="${permissionType == 'own' or permissionType == 'write'}" th:onclick="'javascript:save();'">Save</button>
+			<button th:if="${permissionType == 'own' or permissionType == 'write'}" th:onclick="'javascript:cancel();'">Cancel</button>
 
 			
 			<script type="text/javascript" th:src="@{/js/csvPreview.js}"></script>


### PR DESCRIPTION
This pr is aiming to fix the permission issue on preview tab. 

Current progress:
- If permission = 'none', the preview tab will not render.
- If permission = 'write' or 'owner', the preview tab will render along with edit functionality.

WIP:
- If permission = 'read', we should hide the edit functionality. This is a little tricky, as the preview section is embedded and it doesn't know about the permission. 