### PR TITLE
[288] Support key event on pluggable search

### DIFF
--- a/src/metalnx-web/src/main/javascript/search/components/Search.vue
+++ b/src/metalnx-web/src/main/javascript/search/components/Search.vue
@@ -14,7 +14,8 @@
             required
             autofocus
             placeholder="Enter a search"
-            v-model="searchText"></b-form-input>
+            v-model="searchText"
+            v-on:keyup.enter="search()"></b-form-input>
         <b-button variant="success" slot="append" v-on:click="search()">Search</b-button>
       </b-input-group>
     </div>


### PR DESCRIPTION
This pr supports 'ENTER' key events on the pluggable search page.