### PR TITLE
[295] Render save buttons of preview tab based on permission type

### DIFF
--- a/src/metalnx-web/src/main/java/com/emc/metalnx/controller/PreviewController.java
+++ b/src/metalnx-web/src/main/java/com/emc/metalnx/controller/PreviewController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
@@ -96,6 +97,13 @@ public class PreviewController {
 		previewService.filePreview(previewFilePath, previewMimeType, response);
 	}
 	
+	@RequestMapping(value = "/permissionType", method = RequestMethod.GET, produces = "text/plain")
+	@ResponseBody
+	public String getPermission() throws JargonException {
+		String permissionType = cs.getPermissionsForPath(previewFilePath);
+		return permissionType;
+	}
+
 	@RequestMapping(value = "/save" , method = RequestMethod.POST)
 	public String save(final Model model , @RequestParam("data") final String data) throws JargonException, 
 	DataGridConnectionRefusedException {

--- a/src/metalnx-web/src/main/resources/static/js/preview.js
+++ b/src/metalnx-web/src/main/resources/static/js/preview.js
@@ -41,13 +41,17 @@ $(document).ready(function(){
 			mode = "htmlmixed";
 			
 		} 
-		
+
 		console.log("mode ::" +mode);
 		editor.setOption("mode" , mode);
 		editor.getDoc().setValue(dispData);
 		
     });		
 	
+	$.get("/metalnx/preview/permissionType/", function(data, status, jqXHR) {
+		if(data === 'own' || data === 'write') $("#collectionPreviewSaveButton").show()
+		if(data === 'own' || data === 'write') $("#collectionPreviewCancelButton").show()
+	})
 });
 
 /*function looksLikeScheme(code) {

--- a/src/metalnx-web/src/main/resources/views/collections/preview.html
+++ b/src/metalnx-web/src/main/resources/views/collections/preview.html
@@ -8,7 +8,6 @@
 			<div class="preview-img-container">
 				<img src="/metalnx/preview/dataObjectPreview/"
 					alt="imagePreview" />
-				<span th:text="${permissionType}"></span>
 			</div>
 		</div>
 	</div>
@@ -40,9 +39,9 @@
 			</textarea>
 		</div>
 		<div id="collectionPreviewSearchButtons" class="col-sm-12">
-			<button th:if="${permissionType == 'own' or permissionType == 'write'}" class="btn btn-primary btn-sm pull-right" type="button"
+			<button id="collectionPreviewSaveButton" style="display: none;" class="btn btn-primary btn-sm pull-right" type="button"
 				th:onclick="'javascript:save();'" title="Save">Save</button>
-			<button th:if="${permissionType == 'own' or permissionType == 'write'}" class="btn btn-default btn-sm pull-right" type="button"
+			<button id="collectionPreviewCancelButton" style="display: none;" class="btn btn-default btn-sm pull-right" type="button"
 				th:onclick="'javascript:cancel();'" title="Cancel">Cancel</button>
 		</div>
 
@@ -56,8 +55,8 @@
 			CSV File Preview....
 			<div id="csv" class="preview"></div>
 
-			<button th:if="${permissionType == 'own' or permissionType == 'write'}" th:onclick="'javascript:save();'">Save</button>
-			<button th:if="${permissionType == 'own' or permissionType == 'write'}" th:onclick="'javascript:cancel();'">Cancel</button>
+			<button id="collectionPreviewSaveButton" style="display: none;" th:onclick="'javascript:save();'">Save</button>
+			<button id="collectionPreviewCancelButton" style="display: none;" th:onclick="'javascript:cancel();'">Cancel</button>
 
 			
 			<script type="text/javascript" th:src="@{/js/csvPreview.js}"></script>


### PR DESCRIPTION
This pr modifies the preview controller and fixes the conditional rendering issues (missing save and cancel buttons) on the preview tab. After clicking onto the preview tab, metalnx will load the permission type from the collection service and render buttons based on that. 

If the user only has 'read' permission:
![image](https://user-images.githubusercontent.com/33065086/146259664-9237a776-cdd5-46e2-abfa-139a61749844.png)

If the user has 'write' permission or owns this file: 
![image](https://user-images.githubusercontent.com/33065086/146259745-26c4dbe6-700b-453a-baeb-9ae3ba022f8d.png)

If the user doesn't have access to this file, the preview tab won't render.

@trel I think it's ready for your review, let me know if an issue arises.