### PR TITLE
[297] Gave permission to rodsadmin and groupadmin to modify metadata …

### DIFF
--- a/src/metalnx-web/src/main/resources/views/template/templateFieldList.html
+++ b/src/metalnx-web/src/main/resources/views/template/templateFieldList.html
@@ -4,7 +4,7 @@
 
 
 
-<div class="row" th:with="readonly = ${metadataTemplate != null and metadataTemplate.owner != userDetails.username}">
+<div class="row" th:with="readonly = ${metadataTemplate != null and metadataTemplate.owner != userDetails.username and userDetails.isAdmin() == false and userDetails.isGroupAdmin() == false}">
 	
 	<div class="col-sm-12 table-responsive">
 			

--- a/src/metalnx-web/src/main/resources/views/template/templateForm.html
+++ b/src/metalnx-web/src/main/resources/views/template/templateForm.html
@@ -11,7 +11,7 @@
 	</head>
 	
 	<body>
-		<div layout:fragment="content" th:with="readonly = ${metadataTemplateForm != null and metadataTemplateForm.owner != userDetails.username}" aria-labelledby="templateFormTitle">
+		<div layout:fragment="content" th:with="readonly = ${metadataTemplateForm != null and metadataTemplateForm.owner != userDetails.username and userDetails.isAdmin() == false and userDetails.isGroupAdmin() == false}" aria-labelledby="templateFormTitle">
 			<!-- <h1 class="page-header pull-left" th:text="#{metadata.template.management.page.title}" id="templateFormTitle"></h1> -->
 			<div class="row">
                 <div th:if="${templateNotAddedSuccessfully}" 
@@ -48,7 +48,7 @@
 										type="text" value="" 
 										th:field="*{templateName}" 
 										placeholder="Inform a name for the new template."
-										th:readonly="${readonly ? 'readonly' : 'false'}" 
+										th:disabled="${readonly ? 'readonly' : 'false'}" 
 										maxlength="100"/>
                                     <i class="form-control-feedback glyphicon glyphicon-remove hideElement"
                                         id="invalidTemplateNameIcon"></i>
@@ -66,7 +66,7 @@
 										value="" 
 										th:field="*{description}"
 										placeholder="Add a description to help users select an item from a list of templates."
-										th:readonly="${readonly ? 'readonly' : 'false'}"
+										th:disabled="${readonly ? 'readonly' : 'false'}"
 										required="required"
 										maxlength="100"  >
 									</textarea>
@@ -78,7 +78,7 @@
 								<label class="" for="templateAccessType">*Access</label>
 									<div class="row">
 										<div class="col-xs-5 col-md-6 col-lg-3">
-											<select class="form-control" id="templateAccessType" th:field="*{accessType}" th:readonly="${readonly ? 'readonly' : 'false'}">
+											<select class="form-control" id="templateAccessType" th:field="*{accessType}" th:disabled="${readonly ? 'readonly' : 'false'}">
 												<option th:each="accessType : ${accessTypes}" th:value="${accessType}" th:text="#{${'template.metadata.access_type.' + accessType}}" /> 
 											</select>
 										</div>
@@ -225,9 +225,9 @@
 				function createAccessTypeTooltip() {
 					var accessType = $("#templateAccessType").val();
 					var username = [[${ userDetails.getUsername() }]];
-					
+
 					var icon = '<span class="fa fa-lock"></span>';
-					var message = [[#{templates.metadata.access_type.private.label(${ userDetails.getUsername() })}]];
+					var message = [[#{templates.metadata.access_type.private.label( ${metadataTemplateForm.owner} )}]]
 					
 					if (accessType == 'system') {
 						icon = '<span class="fa fa-globe"></span>';


### PR DESCRIPTION
@trel Alright I've got something for your review. This pr includes the following changes
- admins (rodsadmin and groupadmin) are able to modify the template, or set it as public/private if needed (not sure if we should allow this), and metalnx will also display the template owner in the tooltip
![image](https://user-images.githubusercontent.com/33065086/148294183-db5b0abb-6f1b-42f6-aa79-f7779deb3ef4.png)

- changed read-only template form fields to be 'disabled', so it's not only greyed out but also can't be edited
![image](https://user-images.githubusercontent.com/33065086/148294309-239dfd22-a3d3-4e64-b12e-5856ea9edd1e.png)


So in short, admins are allowed to view/edit/apply all public templates and set templates as private but can't view or edit any private templates. Users are able to view/apply all public templates and edit their own templates.

Does that sound like something we can add to metalnx for now? Or we should wait till the next metadata template meeting?