### PR TITLE
Bumped version of Jargon for bug fixes

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -11,7 +11,7 @@
 	<properties>
 
 		<!-- Jargon -->
-		<jargon.version>4.3.3.0-SNAPSHOT</jargon.version>
+		<jargon.version>4.3.3.0-RELEASE</jargon.version>
 
 		<!-- Spring -->
 		<spring.version>4.3.18.RELEASE</spring.version>


### PR DESCRIPTION
Verified that bumping the version of Jargon resolves the TAR file extension issue.

Someone else needs to test this PR before we merge it.

Leaving as a draft PR until then.