### PR TITLE
[#409] Install regenerator-runtime before building war file (main)

### DIFF
--- a/src/metalnx-web/package.json
+++ b/src/metalnx-web/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
+    "regenerator-runtime": "^0.14.1",
     "view-router": "^0.2.3",
     "vue": "^2.6.11",
     "vue-axios": "^2.1.5",

--- a/src/metalnx-web/pom.xml
+++ b/src/metalnx-web/pom.xml
@@ -325,6 +325,15 @@
 						</configuration>
 					</execution>
 					<execution>
+						<id>npm install regenerator-runtime</id>
+						<goals>
+							<goal>npm</goal>
+						</goals>
+						<configuration>
+							<arguments>install regenerator-runtime --save</arguments>
+						</configuration>
+					</execution>
+					<execution>
 						<id>npm run</id>
 						<goals>
 							<goal>npm</goal>


### PR DESCRIPTION
While the solution presented in the issue does not include the change to package.json, I decided to include it in the PR since that is what ends up happening anyway. By including it, we avoid causing git to report unstaged changes. I believe this pins the version too, which is good.